### PR TITLE
~ reduces queries required to check hash uniqueness

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ class MyModel extends Model
 And create a migration to add a field to store the hash - by default, the field is called `hash` and has a length of 5:
 
 ```
-$table->string('hash', 5);
+$table->string('hash', 5)->unique()->index();
 ```
+
+You may add a unique and index flag for database performance improvements
 
 When new instances of the model are created, they will be assigned a random string.
 

--- a/src/Exceptions/InvalidCharactersInAlphabet.php
+++ b/src/Exceptions/InvalidCharactersInAlphabet.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AdamHopkinson\LaravelModelHash\Exceptions;
+
+use Exception;
+
+class InvalidCharactersInAlphabet extends Exception
+{
+}

--- a/src/Traits/ModelHash.php
+++ b/src/Traits/ModelHash.php
@@ -2,8 +2,9 @@
 
 namespace AdamHopkinson\LaravelModelHash\Traits;
 
+use AdamHopkinson\LaravelModelHash\Exceptions\InvalidCharactersInAlphabet;
 use AdamHopkinson\LaravelModelHash\Exceptions\UniqueHashNotFoundException;
-use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 trait ModelHash
 {
@@ -105,6 +106,10 @@ trait ModelHash
     public function getHashAlphabet()
     {
         if (property_exists($this, 'hashAlphabet')) {
+            if (Str::contains($this->hashAlphabet, ['?', '#', ':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '(', ')', '*', '+', ',', ';', '='])) {
+                throw new InvalidCharactersInAlphabet('Invalid Characters have been found in your alphabet. These must be removed before continuing.');
+            }
+
             return $this->hashAlphabet;
         } else {
             return config('laravelmodelhash.default_alphabet');

--- a/tests/Models/Book.php
+++ b/tests/Models/Book.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AdamHopkinson\LaravelModelHash\Tests\Models;
+
+use AdamHopkinson\LaravelModelHash\Traits\ModelHash;
+use Illuminate\Database\Eloquent\Model;
+
+class Book extends Model
+{
+    use ModelHash;
+
+    /** @var bool */
+    public $timestamps = false;
+
+    /** @var array */
+    protected $guarded = [];
+
+    /** @var string */
+    protected $table = 'books';
+
+    protected $hashAlphabet = '#!?'; // string
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,12 +33,17 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
         $app['db']->connection()->getSchemaBuilder()->create('articles', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('hash', 5);
+            $table->string('hash', 5)->unique()->index();
         });
 
         $app['db']->connection()->getSchemaBuilder()->create('authors', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('key', 6);
+            $table->string('key', 6)->unique()->index();
+        });
+
+        $app['db']->connection()->getSchemaBuilder()->create('books', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('hash', 6)->unique()->index();
         });
     }
 }

--- a/tests/Unit/TraitTest.php
+++ b/tests/Unit/TraitTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace AdamHopkinson\LaravelModelHash\Tests;
 
+use AdamHopkinson\LaravelModelHash\Exceptions\InvalidCharactersInAlphabet;
 use AdamHopkinson\LaravelModelHash\Tests\Models\Article;
 use AdamHopkinson\LaravelModelHash\Tests\Models\Author;
+use AdamHopkinson\LaravelModelHash\Tests\Models\Book;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class TraitTest extends TestCase
@@ -85,5 +87,16 @@ class TraitTest extends TestCase
         $this->assertNotEquals($author->getHashAlphabet(), config('laravelmodelhash.default_alphabet'));
         $this->assertNotEquals($author->getHashMaximumAttempts(), config('laravelmodelhash.maximum_attempts'));
         $this->assertNotEquals($author->getUseHashInRoutes(), config('laravelmodelhash.use_hash_in_routes'));
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Exception
+     */
+    public function throws_error_with_invalid_characters_in_alphabet()
+    {
+        $this->expectException(InvalidCharactersInAlphabet::class);
+        Book::create($record = []);
     }
 }


### PR DESCRIPTION
+ adds error handling for invalid characters in the hash alphabet

My changes are designed to hopefully improve performance, and catch human error.

I have added a unique and index flag to the hash column, this may improve database performance if there are lots of records. 

My change to your check to see if the hash is unique was made with the thought that, if someone uses this package and sets the length quite short, (I used 3 to test this) you may find yourself finding duplicates more frequently. Which can result in up to 10 queries - with the approach of creating a collection of hashes first, it means there will only ever make one request to the database, it also means we can append to that collection, so we have a single source of truth for checked hashes. 

I feel in most use cases of this, given the uniqueness of the hashes, having more than 1 DB query firing off would be rare, but potentially still worth considering - like I said, maybe not an improvement, but a different take on it.

I also added an additional exception, something of a sanity check just in case a user decided they wanted delimiters in their alphabet which will break some requests for example `/tags/xtf?s` would return a 404, as the s would appear to be a query parameter. 

I added a new model and test to cover this eventuality.